### PR TITLE
fix: resolve Docker service connectivity issues

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -83,3 +83,41 @@ logging:
 
 server:
   port: 8080
+
+---
+# Docker Profile Configuration
+spring:
+  config:
+    activate:
+      on-profile: docker
+  
+  # Database Configuration (Docker)
+  datasource:
+    url: jdbc:postgresql://postgres:5432/opencontext
+    username: user
+    password: password
+
+# Application-specific Configuration (Docker)
+app:
+  # Elasticsearch Configuration (Docker)
+  elasticsearch:
+    url: http://elasticsearch:9200
+    index: document_chunks_index
+  
+  # Ollama Configuration (Docker)
+  ollama:
+    api:
+      url: http://ollama:11434
+    embedding:
+      model: dengcao/Qwen3-Embedding-0.6B:F16
+
+# MinIO Configuration (Docker)
+minio:
+  endpoint: http://minio:9000
+  access-key: minioadmin
+  secret-key: minioadmin123!
+  bucket-name: opencontext-documents
+
+# Unstructured.io Configuration (Docker)
+unstructured:
+  base-url: http://unstructured-api:8000


### PR DESCRIPTION
- Add docker profile configuration for container environment
- Update service URLs to use Docker service names instead of localhost
- Fix Ollama connection from localhost:11434 to ollama:11434
- Fix Elasticsearch connection from localhost:9200 to elasticsearch:9200
- Fix MinIO connection from localhost:9000 to minio:9000
- Fix Unstructured API connection from localhost:8000 to unstructured-api:8000
- Enable proper service discovery within Docker network
- Resolves 'Failed to connect to localhost' errors in containerized environment