### PR TITLE
enhance: increase default search results from 5 to 50

### DIFF
--- a/core/src/main/java/com/opencontext/controller/DocsSearchController.java
+++ b/core/src/main/java/com/opencontext/controller/DocsSearchController.java
@@ -25,7 +25,7 @@ public interface DocsSearchController {
     @GetMapping("/search")
     @Operation(
             summary = "Exploratory search (find_knowledge)",
-            description = "Returns top-k structured chunk summaries based on a natural language query. Snippet policy: first 50 chars + '...'."
+            description = "Returns top-k structured chunk summaries based on a natural language query. Default returns 50 results. Snippet policy: first 50 chars + '...'."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Search completed",
@@ -54,8 +54,8 @@ public interface DocsSearchController {
     ResponseEntity<CommonResponse<SearchResultsResponse>> search(
             @Parameter(description = "User search query", example = "Spring Security JWT filter configuration", required = true)
             @RequestParam String query,
-            @Parameter(description = "Max number of results", example = "5")
-            @RequestParam(defaultValue = "5") Integer topK);
+            @Parameter(description = "Max number of results", example = "50")
+            @RequestParam(defaultValue = "50") Integer topK);
 
     @PostMapping(value = "/get-content", consumes = MediaType.APPLICATION_JSON_VALUE)
     @Operation(

--- a/core/src/main/java/com/opencontext/controller/SearchController.java
+++ b/core/src/main/java/com/opencontext/controller/SearchController.java
@@ -35,7 +35,7 @@ public class SearchController implements DocsSearchController {
     @GetMapping("/search")
     public ResponseEntity<CommonResponse<SearchResultsResponse>> search(
             @RequestParam String query,
-            @RequestParam(defaultValue = "5") Integer topK) {
+            @RequestParam(defaultValue = "50") Integer topK) {
         
         log.info("검색 요청: query='{}', topK={}", query, topK);
         


### PR DESCRIPTION
## Summary

This PR enhances the user experience of the MCP search functionality by increasing the default number of search results from 5 to 50. This change provides users with more comprehensive search coverage without requiring manual parameter adjustment.

### Key Changes
- **SearchController**: Updated `topK` default parameter from 5 to 50
- **DocsSearchController**: Updated Swagger documentation to reflect new default value
- **API Documentation**: Enhanced operation description to clarify the new default behavior

### Rationale
The previous default of 5 results was too restrictive for effective exploratory search. Users often need to see a broader range of potentially
relevant content before selecting specific chunks for detailed review. The new default of 50 results:

- Better serves the exploratory search use case (find_knowledge MCP tool)
- Reduces the need for users to manually adjust topK parameters
- Maintains backward compatibility for clients that specify explicit topK values
- Aligns with typical search result expectations in knowledge discovery workflows

### Technical Details
- **Backward Compatibility**: Fully maintained - existing clients can still specify custom topK values
- **Performance Impact**: Minimal - search performance scales well with result count
- **API Changes**: Only default values changed, no breaking changes to API signatures

### Testing Instructions
1. Navigate to `/swagger-ui.html` and test the search endpoint
2. Verify that searches without topK parameter now return up to 50 results by default
3. Confirm that explicit topK parameters still work as expected
4. Test with both small and large result sets to ensure performance remains acceptable

### Files Modified
- `SearchController.java` - Updated default topK parameter
- `DocsSearchController.java` - Updated Swagger documentation and parameter descriptions

### Related Features
- Improves MCP find_knowledge tool effectiveness
- Enhances user experience for knowledge discovery workflows
- Supports more comprehensive search result evaluation